### PR TITLE
Expose mana and level events

### DIFF
--- a/src/main/scala/chuunimod/ChuuniMod.scala
+++ b/src/main/scala/chuunimod/ChuuniMod.scala
@@ -7,7 +7,7 @@ import net.minecraftforge.fml.common.SidedProxy
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent
 import net.minecraftforge.fml.common.network.NetworkRegistry
 
-@Mod(modid = "chuunimod", name = "The Chuunibyou Mod", version = "INDEV", dependencies = "", modLanguage = "scala")
+@Mod(modid = ChuuniMod.MODID, name = ChuuniMod.NAME, version = ChuuniMod.VERSION, dependencies = ChuuniMod.DEPS, modLanguage = "scala")
 object ChuuniMod {
 	final val MODID   = "chuunimod"
 	final val NAME    = "The Chuunibyou Mod"

--- a/src/main/scala/chuunimod/Proxy.scala
+++ b/src/main/scala/chuunimod/Proxy.scala
@@ -1,28 +1,28 @@
 package chuunimod
 
+import java.util.HashMap
+
 import chuunimod.capabilities.LevelHandler
 import chuunimod.capabilities.ManaHandler
-import chuunimod.capabilities.MessageUpdateClientLevel
-import chuunimod.capabilities.MessageUpdateClientMana
 import chuunimod.event.ChuuniEventHandler
 import chuunimod.gui.GuiChuuniOverlay
+import chuunimod.util.MiscUtils.func2callable
 import net.minecraft.client.model.ModelBiped
+import net.minecraft.client.renderer.ItemMeshDefinition
+import net.minecraft.client.renderer.block.model.ModelBakery
 import net.minecraft.client.renderer.block.model.ModelResourceLocation
 import net.minecraft.item.Item
 import net.minecraft.item.ItemArmor
+import net.minecraft.item.ItemStack
+import net.minecraft.util.ResourceLocation
 import net.minecraftforge.client.model.ModelLoader
 import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.common.capabilities.CapabilityManager
-import java.util.HashMap
-import net.minecraft.client.renderer.ItemMeshDefinition
-import net.minecraft.client.renderer.block.model.ModelBakery
-import net.minecraft.util.ResourceLocation
-import net.minecraft.item.ItemStack
 
 class ServerProxy {
 	def preInit {
-		CapabilityManager.INSTANCE.register(classOf[ManaHandler], ManaHandler.getStorageInstance, ManaHandler.getHandlerFactory)
-		CapabilityManager.INSTANCE.register(classOf[LevelHandler], LevelHandler.getStorageInstance, LevelHandler.getHandlerFactory)
+		CapabilityManager.INSTANCE.register(classOf[ManaHandler], new ManaHandler.Storage, ManaHandler.handlerFactory)
+		CapabilityManager.INSTANCE.register(classOf[LevelHandler], new LevelHandler.Storage, LevelHandler.handlerFactory)
 		MinecraftForge.EVENT_BUS.register(new ChuuniEventHandler)
 	}
 }
@@ -54,8 +54,8 @@ class ClientProxy extends ServerProxy {
 	def registerArmorModels {}
 	
 	def registerNetworkPackets {
-		MessageUpdateClientMana.register(ChuuniMod.network, 0)
-		MessageUpdateClientLevel.register(ChuuniMod.network, 1)
+		ManaHandler.registerClientUpdatePacket(ChuuniMod.network, 0)
+		LevelHandler.registerClientUpdatePacket(ChuuniMod.network, 1)
 	}
 	
 	def registerDefaultItemModel(item:Item) = ModelLoader.setCustomModelResourceLocation(item, 0, new ModelResourceLocation(item.getRegistryName.toString))
@@ -64,7 +64,7 @@ class ClientProxy extends ServerProxy {
 		ModelBakery.registerItemVariants(item, variants map { v => new ResourceLocation(item.getRegistryName+v) }:_*)
 		ModelLoader.setCustomMeshDefinition(item, mesh)
 	}
-	def variantItemModelFactory(variants:List[String], mesh:ItemMeshDefinition)(item:Item) { registerVariantItemModel(item, variants, mesh) }
+	def variantItemModelFactory(variants:List[String], mesh:ItemMeshDefinition)(item:Item) = registerVariantItemModel(item, variants, mesh)
 }
 
 object ClientProxy {

--- a/src/main/scala/chuunimod/Registry.scala
+++ b/src/main/scala/chuunimod/Registry.scala
@@ -3,11 +3,9 @@ package chuunimod
 import chuunimod.item.ItemArmorPairingManaWeapon
 import chuunimod.item.ItemCharacterArmor
 import net.minecraft.creativetab.CreativeTabs
-import net.minecraft.init.Items
 import net.minecraft.inventory.EntityEquipmentSlot
 import net.minecraft.item.Item
 import net.minecraft.item.ItemStack
-import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.registry.GameRegistry
 
 object Registry {

--- a/src/main/scala/chuunimod/capabilities/CapabilityBase.scala
+++ b/src/main/scala/chuunimod/capabilities/CapabilityBase.scala
@@ -1,0 +1,101 @@
+package chuunimod.capabilities
+
+import chuunimod.ChuuniMod
+import chuunimod.util.MiscUtils.func2runnable
+import chuunimod.util.MiscUtils.nbtcomp2map
+import io.netty.buffer.ByteBuf
+import net.minecraft.client.Minecraft
+import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.entity.player.EntityPlayerMP
+import net.minecraft.nbt.NBTBase
+import net.minecraft.nbt.NBTTagCompound
+import net.minecraft.util.EnumFacing
+import net.minecraft.util.ResourceLocation
+import net.minecraftforge.common.MinecraftForge
+import net.minecraftforge.common.capabilities.Capability
+import net.minecraftforge.common.capabilities.Capability.IStorage
+import net.minecraftforge.common.capabilities.ICapabilitySerializable
+import net.minecraftforge.event.AttachCapabilitiesEvent
+import net.minecraftforge.event.entity.player.PlayerEvent
+import net.minecraftforge.fml.common.Mod
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import net.minecraftforge.fml.common.gameevent.TickEvent.PlayerTickEvent
+import net.minecraftforge.fml.common.network.ByteBufUtils
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext
+import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper
+import net.minecraftforge.fml.relauncher.Side
+import scala.reflect.macros.blackbox.Context
+
+abstract class CapabilityBase[T <: CapabilityBase[T]](val CAP:() => Capability[T]) extends ICapabilitySerializable[NBTTagCompound] {
+	val player:EntityPlayer
+	private var ticksAttached = 0
+	final def ready = ticksAttached > 20
+	
+	def hasCapability(capability:Capability[_], f:EnumFacing) = capability == CAP()
+	def getCapability[T](capability:Capability[T], f:EnumFacing) = { if(capability == CAP()) this else null }.asInstanceOf[T]
+	
+	def updateClient:Unit = 
+		if(!player.worldObj.isRemote) ChuuniMod.network.sendTo(getClientUpdatePacket, player.asInstanceOf[EntityPlayerMP])
+	def getClientUpdatePacket:IMessage
+		
+	@SubscribeEvent final def onTick_(e:PlayerTickEvent) = { if(e.player == player) onTick(e); ticksAttached += 1 }
+	protected def onTick(e:PlayerTickEvent)
+	
+	def deserializeNBT(nbt:NBTTagCompound) = (nbt:Map[String,Any]) foreach { case (key,value) => {
+		this.getClass.getMethods.find(_.getName == key + "_$eq") match {
+			case Some(s) => s.invoke(this, value.asInstanceOf[AnyRef])
+			case None =>
+		}
+	}}
+}
+
+abstract class StorageBase[T <: CapabilityBase[T]] extends IStorage[T] {
+	def writeNBT(cap:Capability[T], ins:T, f:EnumFacing) = ins.serializeNBT
+	def readNBT(cap:Capability[T], ins:T, f:EnumFacing, nbt:NBTBase) = ins.deserializeNBT(nbt.asInstanceOf[NBTTagCompound])
+}
+
+trait CapabilityCompanion[T <: CapabilityBase[T] with HandlerLike[H], H <: HandlerLike[H]] {
+	def CAP:Capability[T]
+	val NAME:String
+	
+	def newInstance(player:EntityPlayer):T
+	val handlerFactory:() => T
+	
+	def instanceFor(player:EntityPlayer):T = player.getCapability(CAP, null)
+	class Storage extends StorageBase[T]
+	
+	def attachToPlayer(e:AttachCapabilitiesEvent.Entity) {
+			val handler = newInstance(e.getEntity.asInstanceOf[EntityPlayer])
+			e.addCapability(new ResourceLocation(ChuuniMod.MODID, NAME), handler)
+			MinecraftForge.EVENT_BUS.register(handler)
+	}
+	
+	def persistOnPlayer(e:PlayerEvent.Clone) {
+		instanceFor(e.getOriginal).copyTo(instanceFor(e.getEntityPlayer).asInstanceOf[H])
+		MinecraftForge.EVENT_BUS.unregister(instanceFor(e.getOriginal))
+	}
+	
+	abstract class MessageUpdateClientBase(var nbt:NBTTagCompound) extends IMessage {
+		def toBytes(buf:ByteBuf) = ByteBufUtils.writeTag(buf, nbt)
+		def fromBytes(buf:ByteBuf) = nbt = ByteBufUtils.readTag(buf)
+	}
+	
+	abstract class MessageUpdateClientHandlerBase[T <: MessageUpdateClientBase] extends IMessageHandler[T, IMessage] {
+		def onMessage(msg:T, context:MessageContext) = {
+			Minecraft.getMinecraft.addScheduledTask(() => {
+				val player = Minecraft.getMinecraft.thePlayer
+				instanceFor(player).deserializeNBT(msg.nbt)
+			})
+			null
+		}
+	}
+
+	def registerClientUpdatePacket[H <: MessageUpdateClientHandlerBase[M], M <: MessageUpdateClientBase]
+		(net:SimpleNetworkWrapper, id:Int)(implicit handler:Manifest[H], msg:Manifest[M]) = 
+			net.registerMessage(handler.erasure.asInstanceOf[Class[H]], msg.erasure.asInstanceOf[Class[M]], id, Side.CLIENT)
+	def registerClientUpdatePacket(net:SimpleNetworkWrapper, id:Int)
+}
+
+trait HandlerLike[T <: HandlerLike[T]] { def copyTo(other:T) }

--- a/src/main/scala/chuunimod/event/ChuuniEvent.scala
+++ b/src/main/scala/chuunimod/event/ChuuniEvent.scala
@@ -1,7 +1,0 @@
-package chuunimod.event
-
-import net.minecraftforge.fml.common.eventhandler.Event
-import net.minecraft.entity.player.EntityPlayer
-import chuunimod.capabilities.LevelHandler
-
-class ChuuniLevelUpEvent(val player:EntityPlayer, val lh:LevelHandler) extends Event

--- a/src/main/scala/chuunimod/event/ChuuniEventHandler.scala
+++ b/src/main/scala/chuunimod/event/ChuuniEventHandler.scala
@@ -11,12 +11,11 @@ import net.minecraft.entity.monster.EntityGhast
 import net.minecraft.entity.monster.EntityMob
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.util.ResourceLocation
-import net.minecraftforge.common.MinecraftForge
+import net.minecraft.util.text.TextComponentString
 import net.minecraftforge.event.AttachCapabilitiesEvent
 import net.minecraftforge.event.entity.EntityJoinWorldEvent
 import net.minecraftforge.event.entity.living.LivingDeathEvent
 import net.minecraftforge.event.entity.player.PlayerEvent
-import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent.Phase
 import net.minecraftforge.fml.common.gameevent.TickEvent.PlayerTickEvent
@@ -27,46 +26,21 @@ class ChuuniEventHandler {
 	
 	@SubscribeEvent def addPlayerCapabilities(e:AttachCapabilitiesEvent.Entity) {
 		if(e.getEntity.isInstanceOf[EntityPlayer]) {
-			e.addCapability(new ResourceLocation(ChuuniMod.MODID, "ManaHandler"), ManaHandler.getHandlerInstance)
-			e.addCapability(new ResourceLocation(ChuuniMod.MODID, "LevelHandler"), LevelHandler.getHandlerInstance)
+			ManaHandler.attachToPlayer(e)
+			LevelHandler.attachToPlayer(e)
 		}
 	}
 	
 	@SubscribeEvent def persistPlayerCapabilities(e:PlayerEvent.Clone) {
-		ManaHandler.instanceFor(e.getOriginal).copyTo(ManaHandler.instanceFor(e.getEntityPlayer), !e.isWasDeath)
-		LevelHandler.instanceFor(e.getOriginal).copyTo(LevelHandler.instanceFor(e.getEntityPlayer))
+		ManaHandler.persistOnPlayer(e)
+		LevelHandler.persistOnPlayer(e)
 	}
 	
 	@SubscribeEvent def updateClientOnJoinWorld(e:EntityJoinWorldEvent) {
 		val player = if(e.getEntity.isInstanceOf[EntityPlayer]) e.getEntity.asInstanceOf[EntityPlayer] else return
 		
-		ManaHandler.instanceFor(player).updateClient(player, true)
-		LevelHandler.instanceFor(player).updateClient(player, true)
-	}
-	
-	//===== PLAYER TICK =====//
-	
-	@SubscribeEvent def onPlayerTick(e:PlayerTickEvent) {
-		if(e.phase != Phase.END) return
-		
-		if(!e.player.worldObj.isRemote) {
-			updatePlayerMana(e.player)
-			updatePlayerLevel(e.player)
-		}
-	}
-	
-	def updatePlayerMana(player:EntityPlayer) {
-		val mh = ManaHandler.instanceFor(player)
-		
-		if(!player.isDead) mh.regenMana(mh.manaRegen)
-		mh.updateClient(player)
-	}
-	
-	def updatePlayerLevel(player:EntityPlayer) {
-		val lh = LevelHandler.instanceFor(player)
-
-		if(lh.shouldFireLevelUpEvent) MinecraftForge.EVENT_BUS.post(new ChuuniLevelUpEvent(player, lh))
-		lh.updateClient(player)
+		ManaHandler.instanceFor(player).updateClient
+		LevelHandler.instanceFor(player).updateClient
 	}
 	
 	//===== HURT/KILL ENEMY =====//
@@ -78,7 +52,7 @@ class ChuuniEventHandler {
 			val player = e.getSource.getEntity.asInstanceOf[EntityPlayer]
 			val lh = LevelHandler.instanceFor(player)
 			
-			val expRange:(Float,Float) = e.getEntityLiving match {
+			val expRange:(Int,Int) = e.getEntityLiving match {
 				case _:EntityDragon => (95000,150000)
 				case _:EntityWither => (4000,6000)
 				case _:EntityGhast if e.getSource.getDamageType == "fireball" => (750,1250)
@@ -86,15 +60,21 @@ class ChuuniEventHandler {
 				case _:EntityMob => (50,150)
 				case _ => (25,75)
 			}
-			lh.addExp(ThreadLocalRandom.current.nextDouble(expRange._1, expRange._2).toFloat)
+			lh.addExp(ThreadLocalRandom.current.nextInt(expRange._1, expRange._2))
 		}
 	}
 	
 	//===== CHUUNI EVENTS =====//
 	
-	@SubscribeEvent def onPlayerLevelUp(e:ChuuniLevelUpEvent) {
+	@SubscribeEvent def onPlayerLevelUp(e:LevelHandler.LevelUpEvent) {
 		val mh = ManaHandler.instanceFor(e.player)
-		mh.setMaxMana(250*e.lh.level)
+		mh.setMaxMana(250*e.newLevel) //TODO: balance and change regen (change from max +250 per level to max *2 on even, regen *2 on odd?)
+		
+		if(e.player.worldObj.isRemote && e.newLevel > e.oldLevel) e.player.addChatComponentMessage(new TextComponentString("You leveled up!"))
+	}
+	
+	@SubscribeEvent def onPlayerLevelMax(e:LevelHandler.LevelMaxEvent) {
+		if(e.player.worldObj.isRemote) e.player.addChatComponentMessage(new TextComponentString("You hit the maximum level!"))
 	}
 	
 }

--- a/src/main/scala/chuunimod/gui/GuiChuuniOverlay.scala
+++ b/src/main/scala/chuunimod/gui/GuiChuuniOverlay.scala
@@ -1,5 +1,6 @@
 package chuunimod.gui
 
+import chuunimod.capabilities.LevelHandler
 import chuunimod.capabilities.ManaHandler
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.Gui
@@ -7,7 +8,6 @@ import net.minecraft.client.resources.I18n
 import net.minecraftforge.client.event.RenderGameOverlayEvent
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import chuunimod.capabilities.LevelHandler
 
 class GuiChuuniOverlay extends Gui {
 	

--- a/src/main/scala/chuunimod/util/MiscUtils.scala
+++ b/src/main/scala/chuunimod/util/MiscUtils.scala
@@ -1,0 +1,61 @@
+package chuunimod.util
+
+import java.util.UUID
+import java.util.concurrent.Callable
+
+import scala.collection.JavaConversions.asScalaSet
+
+import net.minecraft.nbt.NBTBase
+import net.minecraft.nbt.NBTException
+import net.minecraft.nbt.NBTTagByte
+import net.minecraft.nbt.NBTTagByteArray
+import net.minecraft.nbt.NBTTagCompound
+import net.minecraft.nbt.NBTTagDouble
+import net.minecraft.nbt.NBTTagFloat
+import net.minecraft.nbt.NBTTagInt
+import net.minecraft.nbt.NBTTagIntArray
+import net.minecraft.nbt.NBTTagLong
+import net.minecraft.nbt.NBTTagShort
+import net.minecraft.nbt.NBTTagString
+
+object MiscUtils {
+	implicit def func2callable[T](f:() => T):Callable[T] = new Callable[T] { def call = f() }
+	implicit def func2runnable(f:() => Unit):Runnable = new Runnable { def run = f() }
+	
+	implicit def map2nbtcomp(m:Map[String,Any]):NBTTagCompound = {
+		val nbt = new NBTTagCompound
+		m.keys foreach { (key) => m.get(key).get match {
+			case v:NBTBase => nbt.setTag(key, v)
+			case v:Byte => nbt.setByte(key, v)
+			case v:Short => nbt.setShort(key, v)
+			case v:Int => nbt.setInteger(key, v)
+			case v:Long => nbt.setLong(key, v)
+			case v:UUID => nbt.setUniqueId(key, v)
+			case v:Float => nbt.setFloat(key, v)
+			case v:Double => nbt.setDouble(key, v)
+			case v:String => nbt.setString(key, v)
+			case v:Array[Byte] => nbt.setByteArray(key, v)
+			case v:Array[Int] => nbt.setIntArray(key, v)
+			case v:Boolean => nbt.setBoolean(key, v)
+			case v => throw new NBTException(s"Cannot serialize $v to NBT")
+		}}
+		nbt		
+	}
+	
+	implicit def nbtcomp2map(nbt:NBTTagCompound):Map[String,Any] = {
+		var map = Map[String,Any]()
+		nbt.getKeySet foreach { (key) => nbt.getTag(key) match {
+			case v:NBTTagByte => map = map+(key -> v.getByte)
+			case v:NBTTagShort => map = map+(key -> v.getShort)
+			case v:NBTTagInt => map = map+(key -> v.getInt)
+			case v:NBTTagLong => map = map+(key -> v.getLong)
+			case v:NBTTagFloat => map = map+(key -> v.getFloat)
+			case v:NBTTagDouble => map = map+(key -> v.getDouble)
+			case v:NBTTagString => map = map+(key -> v.getString)
+			case v:NBTTagByteArray => map = map+(key -> v.getByteArray)
+			case v:NBTTagIntArray => map = map+(key -> v.getIntArray)
+			case v => map = map+(key -> v)
+		}}
+		map
+	}
+}


### PR DESCRIPTION
Reworks the capability systems linked to level and mana handling to be more abstracted and generally better built, all in order (mainly) to both reduce overall repeated code and allow for easy exposing of level and mana related events.
