### PR TITLE
Fix events not firing in built version of mod

### DIFF
--- a/src/main/scala/chuunimod/capabilities/CapabilityBase.scala
+++ b/src/main/scala/chuunimod/capabilities/CapabilityBase.scala
@@ -40,7 +40,7 @@ abstract class CapabilityBase[T <: CapabilityBase[T]](val CAP:() => Capability[T
 		if(!player.worldObj.isRemote) ChuuniMod.network.sendTo(getClientUpdatePacket, player.asInstanceOf[EntityPlayerMP])
 	def getClientUpdatePacket:IMessage
 		
-	@SubscribeEvent final def onTick_(e:PlayerTickEvent) = { if(e.player == player) onTick(e); ticksAttached += 1 }
+	@SubscribeEvent final def onTick_(e:PlayerTickEvent) = { if(e.player.getUniqueID == player.getUniqueID) onTick(e); ticksAttached += 1 }
 	protected def onTick(e:PlayerTickEvent)
 	
 	def deserializeNBT(nbt:NBTTagCompound) = (nbt:Map[String,Any]) foreach { case (key,value) => {

--- a/src/main/scala/chuunimod/capabilities/LevelHandler.scala
+++ b/src/main/scala/chuunimod/capabilities/LevelHandler.scala
@@ -8,6 +8,9 @@ import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.fml.common.eventhandler.Event
 import net.minecraftforge.fml.common.gameevent.TickEvent.PlayerTickEvent
 import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper
+import net.minecraft.util.text.TextComponentString
+import chuunimod.event.LevelUpEvent
+import chuunimod.event.LevelMaxEvent
 
 trait LevelHandlerLike extends HandlerLike[LevelHandlerLike] {
 	var level,exp,maxLevel:Int
@@ -48,8 +51,8 @@ class LevelHandler(val player:EntityPlayer=null) extends CapabilityBase[LevelHan
 	
 	def onTick(e:PlayerTickEvent) {
 		if(ready && level != lastLevel) {
-			MinecraftForge.EVENT_BUS.post(LevelUpEvent(player, lastLevel, level))
-			if(level == maxLevel) MinecraftForge.EVENT_BUS.post(LevelMaxEvent(player, lastLevel, level))
+			MinecraftForge.EVENT_BUS.post(new LevelUpEvent(player, lastLevel, level))
+			if(level == maxLevel) MinecraftForge.EVENT_BUS.post(new LevelMaxEvent(player, lastLevel, level))
 		}
 		
 		if(hasChanged) { updateClient; updateLast }
@@ -69,9 +72,6 @@ object LevelHandler extends CapabilityCompanion[LevelHandler, LevelHandlerLike] 
 	class MessageUpdateClient(nbt:NBTTagCompound) extends MessageUpdateClientBase(nbt) { def this() = this(null) }
 	class MessageUpdateClientHandler extends MessageUpdateClientHandlerBase[MessageUpdateClient]
 	def registerClientUpdatePacket(net:SimpleNetworkWrapper, id:Int) = super.registerClientUpdatePacket[MessageUpdateClientHandler,MessageUpdateClient](net, id)
-	
-	case class LevelUpEvent(val player:EntityPlayer, val oldLevel:Int, val newLevel:Int) extends Event
-	case class LevelMaxEvent(val player:EntityPlayer, val oldLevel:Int, val newLevel:Int) extends Event
 }
 
 

--- a/src/main/scala/chuunimod/capabilities/ManaHandler.scala
+++ b/src/main/scala/chuunimod/capabilities/ManaHandler.scala
@@ -8,6 +8,8 @@ import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper
 import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.fml.common.eventhandler.Event
 import net.minecraftforge.event.entity.player.PlayerEvent
+import chuunimod.event.ManaFullEvent
+import chuunimod.event.ManaEmptyEvent
 
 trait ManaHandlerLike extends HandlerLike[ManaHandlerLike] {
 	var mana,maxMana,manaRegen:Float
@@ -38,8 +40,8 @@ class ManaHandler(val player:EntityPlayer=null) extends CapabilityBase[ManaHandl
 		if(!e.player.worldObj.isRemote) regenMana(manaRegen)
 		
 		if(ready && mana != lastMana) {
-			if(mana == 0) MinecraftForge.EVENT_BUS.post(ManaEmptyEvent(player, mana))
-			if(mana == maxMana) MinecraftForge.EVENT_BUS.post(ManaFullEvent(player, mana))
+			if(mana == 0) MinecraftForge.EVENT_BUS.post(new ManaEmptyEvent(player, mana))
+			if(mana == maxMana) MinecraftForge.EVENT_BUS.post(new ManaFullEvent(player, mana))
 		}
 		
 		if(hasChanged) { updateClient; updateLast }
@@ -61,7 +63,4 @@ object ManaHandler extends CapabilityCompanion[ManaHandler, ManaHandlerLike] {
 	def registerClientUpdatePacket(net:SimpleNetworkWrapper, id:Int) = super.registerClientUpdatePacket[MessageUpdateClientHandler,MessageUpdateClient](net, id)
 	
 	override def persistOnPlayer(e:PlayerEvent.Clone) { super.persistOnPlayer(e); if(e.isWasDeath) instanceFor(e.getEntityPlayer).setMana(0) }
-	
-	case class ManaEmptyEvent(val player:EntityPlayer, val mana:Float) extends Event
-	case class ManaFullEvent(val player:EntityPlayer, val mana:Float) extends Event
 }

--- a/src/main/scala/chuunimod/event/ChuuniEventHandler.scala
+++ b/src/main/scala/chuunimod/event/ChuuniEventHandler.scala
@@ -2,7 +2,6 @@ package chuunimod.event
 
 import java.util.concurrent.ThreadLocalRandom
 
-import chuunimod.ChuuniMod
 import chuunimod.capabilities.LevelHandler
 import chuunimod.capabilities.ManaHandler
 import net.minecraft.entity.boss.EntityDragon
@@ -10,15 +9,12 @@ import net.minecraft.entity.boss.EntityWither
 import net.minecraft.entity.monster.EntityGhast
 import net.minecraft.entity.monster.EntityMob
 import net.minecraft.entity.player.EntityPlayer
-import net.minecraft.util.ResourceLocation
 import net.minecraft.util.text.TextComponentString
 import net.minecraftforge.event.AttachCapabilitiesEvent
 import net.minecraftforge.event.entity.EntityJoinWorldEvent
 import net.minecraftforge.event.entity.living.LivingDeathEvent
 import net.minecraftforge.event.entity.player.PlayerEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import net.minecraftforge.fml.common.gameevent.TickEvent.Phase
-import net.minecraftforge.fml.common.gameevent.TickEvent.PlayerTickEvent
 
 class ChuuniEventHandler {
 	
@@ -66,14 +62,14 @@ class ChuuniEventHandler {
 	
 	//===== CHUUNI EVENTS =====//
 	
-	@SubscribeEvent def onPlayerLevelUp(e:LevelHandler.LevelUpEvent) {
+	@SubscribeEvent def onPlayerLevelUp(e:LevelUpEvent) {
 		val mh = ManaHandler.instanceFor(e.player)
 		mh.setMaxMana(250*e.newLevel) //TODO: balance and change regen (change from max +250 per level to max *2 on even, regen *2 on odd?)
 		
 		if(e.player.worldObj.isRemote && e.newLevel > e.oldLevel) e.player.addChatComponentMessage(new TextComponentString("You leveled up!"))
 	}
 	
-	@SubscribeEvent def onPlayerLevelMax(e:LevelHandler.LevelMaxEvent) {
+	@SubscribeEvent def onPlayerLevelMax(e:LevelMaxEvent) {
 		if(e.player.worldObj.isRemote) e.player.addChatComponentMessage(new TextComponentString("You hit the maximum level!"))
 	}
 	

--- a/src/main/scala/chuunimod/event/LevelMaxEvent.java
+++ b/src/main/scala/chuunimod/event/LevelMaxEvent.java
@@ -1,0 +1,18 @@
+package chuunimod.event;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class LevelMaxEvent extends Event {
+	
+	public final EntityPlayer player;
+	public final int oldLevel;
+	public final int newLevel;
+	
+	public LevelMaxEvent(EntityPlayer player, int oldLevel, int newLevel) {
+		this.player = player;
+		this.oldLevel = oldLevel;
+		this.newLevel = newLevel;
+	}
+
+}

--- a/src/main/scala/chuunimod/event/LevelUpEvent.java
+++ b/src/main/scala/chuunimod/event/LevelUpEvent.java
@@ -1,0 +1,18 @@
+package chuunimod.event;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class LevelUpEvent extends Event {
+	
+	public final EntityPlayer player;
+	public final int oldLevel;
+	public final int newLevel;
+	
+	public LevelUpEvent(EntityPlayer player, int oldLevel, int newLevel) {
+		this.player = player;
+		this.oldLevel = oldLevel;
+		this.newLevel = newLevel;
+	}
+
+}

--- a/src/main/scala/chuunimod/event/ManaEmptyEvent.java
+++ b/src/main/scala/chuunimod/event/ManaEmptyEvent.java
@@ -1,0 +1,16 @@
+package chuunimod.event;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class ManaEmptyEvent extends Event {
+
+	public final EntityPlayer player;
+	public final float mana;
+	
+	public ManaEmptyEvent(EntityPlayer player, float mana) {
+		this.player = player;
+		this.mana = mana;
+	}
+	
+}

--- a/src/main/scala/chuunimod/event/ManaFullEvent.java
+++ b/src/main/scala/chuunimod/event/ManaFullEvent.java
@@ -1,0 +1,16 @@
+package chuunimod.event;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class ManaFullEvent extends Event {
+
+	public final EntityPlayer player;
+	public final float mana;
+	
+	public ManaFullEvent(EntityPlayer player, float mana) {
+		this.player = player;
+		this.mana = mana;
+	}
+	
+}


### PR DESCRIPTION
Level and mana events were not being fired outside of the development environment due to issues with Forge's dangerous amounts of reflection. The event definitions have been moved to Java code to solve this.